### PR TITLE
feat: add returned_items method to get merchants action

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -3,8 +3,9 @@ class Api::V1::MerchantsController < ApplicationController
   def index
     merchants = Merchant.all
 
+    merchants = Merchant.returned_items("returned") if params[:status] == "returned"
     merchants = merchants.sort_by_age if params[:sorted] == "age"
-
+    
     render json: MerchantIndexSerializer.new(merchants)
   end
 
@@ -16,7 +17,7 @@ class Api::V1::MerchantsController < ApplicationController
       rescue ActiveRecord::RecordInvalid => exception
         render json: {
           'message': "your query could not be completed",
-          'errors': exception.record.errors.full_messages
+          'errors': [exception.message]
       }, status: :bad_request
     end
   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,4 +6,8 @@ class Merchant < ApplicationRecord
   def self.sort_by_age
     order('created_at asc')
   end
+
+  def self.returned_items(status)
+    joins(:invoices).where(invoices: { status: status})
+  end
 end

--- a/spec/requests/api/v1/merchant_invoices_request_spec.rb
+++ b/spec/requests/api/v1/merchant_invoices_request_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe "MerchantInvoices" do
+  before :each do
+    @merchant1 = Merchant.create(name: "Little Shop of Horrors")
+    @merchant2 = Merchant.create(name: "Large Shop of Wonders")
+    @merchant3 = Merchant.create(name: "Wizard's Chest")
+  end
+
+  it 'returns all invoices for a given merchant' do
+    merchant = Merchant.create!(name: "Test Merchant")
+    bob = Customer.create!(first_name: "Bob", last_name: "Tucker")
+    kathy = Customer.create!(first_name: "Kathy", last_name: "Tucker")
+    invoice1 = Invoice.create!(customer_id: bob.id, merchant_id: merchant.id, status: "shipped")
+    invoice2 = Invoice.create!(customer_id: kathy.id, merchant_id: merchant.id, status: "shipped")
+
+    get "/api/v1/merchants/#{merchant.id}/invoices?status=shipped"
+    
+    expect(response).to be_successful
+
+    response_data = JSON.parse(response.body, symbolize_names: true)
+    expect(response_data[:data].count).to eq(2)
+  end
+
+  it 'gets all merchants with returned items' do
+    bob = Customer.create!(first_name: "Bob", last_name: "Tucker")
+    kathy = Customer.create!(first_name: "Kathy", last_name: "Tucker")
+    invoice1 = Invoice.create!(customer_id: bob.id, merchant_id: @merchant1.id, status: "returned")
+    invoice2 = Invoice.create!(customer_id: kathy.id, merchant_id: @merchant2.id, status: "shipped")
+
+    get "/api/v1/merchants?status=returned"
+
+    expect(response).to be_successful
+
+    response_data = JSON.parse(response.body, symbolize_names: true)
+    # binding.pry
+    expect(response_data[:data].count).to eq(1)
+  end
+end


### PR DESCRIPTION
This PR adds a method to get all merchants with invoices that have a "returned" status. It also creates a spec file for merchant invoices requests. 